### PR TITLE
deprecate(createConstants): babel 6 doesnt allow exports to work this…

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,19 +251,8 @@ Coverage reports will be compiled to `~/coverage` by default. If you wish to cha
 Utilities
 ---------
 
-This boilerplate comes with two simple utilities (thanks to [StevenLangbroek](https://github.com/StevenLangbroek)) to help speed up your Redux development process. In `~/client/utils` you'll find exports for `createConstants` and `createReducer`. The former is pretty much an even lazier `keyMirror`, so if you _really_ hate typing out those constants you may want to give it a shot. Check it out:
+This boilerplate comes with a simple utility (thanks to [StevenLangbroek](https://github.com/StevenLangbroek)) to help speed up your Redux development process. In `~/client/utils` you'll find an export for `createReducer` which is designed to expedite creating reducers when they're defined via an object map rather than switch statements. As an example, what once looked like this:
 
-```js
-import { createConstants } from 'utils';
-
-export default createConstants(
-  'TODO_CREATE',
-  'TODO_DESTROY',
-  'TODO_TOGGLE_COMPLETE'
-);
-```
-
-The other utility, `create-reducer`, is designed to expedite creating reducers when they're defined via an object map rather than switch statements. As an example, what once looked like this:
 
 ```js
 import { TODO_CREATE } from 'constants/todo';

--- a/src/constants/counter.js
+++ b/src/constants/counter.js
@@ -1,5 +1,1 @@
-import { createConstants } from '../utils';
-
-export default createConstants(
-  'COUNTER_INCREMENT'
-);
+export const COUNTER_INCREMENT = 'COUNTER_INCREMENT';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,13 +3,6 @@ import ReactDOM     from 'react-dom';
 import { Provider } from 'react-redux';
 import DevTools     from 'containers/DevToolsWindow';
 
-export function createConstants (...constants) {
-  return constants.reduce((acc, constant) => {
-    acc[constant] = constant;
-    return acc;
-  }, {});
-}
-
 export function createReducer (initialState, fnMap) {
   // possible use of rest arguments: https://github.com/rackt/redux/issues/749#issuecomment-141570236
   return (state = initialState, { type, payload }) => {


### PR DESCRIPTION
… way